### PR TITLE
Implement global error handling

### DIFF
--- a/app/composeApp/src/commonMain/kotlin/de/ashman/ontrack/network/account/AccountService.kt
+++ b/app/composeApp/src/commonMain/kotlin/de/ashman/ontrack/network/account/AccountService.kt
@@ -40,6 +40,7 @@ class AccountServiceImpl(
         when (apiResponse.status) {
             HttpStatusCode.OK -> AccountResult.Success
             HttpStatusCode.Conflict -> {
+                // TODO handle new error type here
                 val error = mapUsernameError(apiResponse.data)
                 AccountResult.InvalidUsername(error)
             }

--- a/backend/src/main/kotlin/de/ashman/ontrack/config/SecurityConfig.kt
+++ b/backend/src/main/kotlin/de/ashman/ontrack/config/SecurityConfig.kt
@@ -19,7 +19,8 @@ class SecurityConfig(
         http
             .csrf { csrf -> csrf.disable() }
             .authorizeHttpRequests { auth ->
-                auth.anyRequest().authenticated()
+                auth.requestMatchers("/error").permitAll()
+                    .anyRequest().authenticated()
             }
             .addFilterBefore(firebaseAuthFilter, AuthorizationFilter::class.java)
 

--- a/backend/src/main/kotlin/de/ashman/ontrack/errorhandling/DomainException.kt
+++ b/backend/src/main/kotlin/de/ashman/ontrack/errorhandling/DomainException.kt
@@ -1,0 +1,3 @@
+package de.ashman.ontrack.errorhandling
+
+class DomainException(message: String) : RuntimeException(message)

--- a/backend/src/main/kotlin/de/ashman/ontrack/errorhandling/ErrorType.kt
+++ b/backend/src/main/kotlin/de/ashman/ontrack/errorhandling/ErrorType.kt
@@ -1,0 +1,5 @@
+package de.ashman.ontrack.errorhandling
+
+enum class ErrorType {
+   ValidationError, DomainError
+}

--- a/backend/src/main/kotlin/de/ashman/ontrack/errorhandling/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/de/ashman/ontrack/errorhandling/GlobalExceptionHandler.kt
@@ -1,0 +1,63 @@
+package de.ashman.ontrack.errorhandling
+
+import org.springframework.http.HttpStatus
+import org.springframework.http.ProblemDetail
+import org.springframework.web.ErrorResponse
+import org.springframework.web.ErrorResponseException
+import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import java.net.URI
+
+@RestControllerAdvice
+class GlobalExceptionHandler {
+    @ExceptionHandler(MethodArgumentNotValidException::class)
+    fun handleValidationException(exception: MethodArgumentNotValidException): ErrorResponse
+    {
+        val errors = HashMap<String, MutableList<String>>()
+        exception
+            .bindingResult
+            .fieldErrors
+            .forEach { error ->
+                val fieldErrors = errors.getOrPut(error.field) { mutableListOf() }
+                fieldErrors.add(error.defaultMessage.orEmpty())
+            }
+        val problem = ProblemDetail.forStatus(HttpStatus.CONFLICT)
+        problem.type = URI.create(ErrorType.ValidationError.name)
+        problem.detail = "Validation failed for one or more fields"
+        problem.setProperty("errors", errors)
+
+        return ErrorResponseException(
+            HttpStatus.CONFLICT,
+            problem,
+            exception,
+        )
+    }
+
+    @ExceptionHandler(ValidationException::class)
+    fun handleValidationException(exception: ValidationException): ErrorResponse {
+        val problem = ProblemDetail.forStatus(HttpStatus.CONFLICT)
+        problem.type = URI.create(ErrorType.ValidationError.name)
+        problem.detail = "Validation failed"
+        problem.setProperty("errors", exception.errors)
+
+        return ErrorResponseException(
+            HttpStatus.CONFLICT,
+            problem,
+            exception,
+        )
+    }
+
+    @ExceptionHandler(DomainException::class)
+    fun handleDomainException(exception: DomainException): ErrorResponse {
+        val problem = ProblemDetail.forStatus(HttpStatus.CONFLICT)
+        problem.type = URI.create(ErrorType.DomainError.name)
+        problem.detail = exception.message
+
+        return ErrorResponseException(
+            HttpStatus.CONFLICT,
+            problem,
+            exception,
+        )
+    }
+}

--- a/backend/src/main/kotlin/de/ashman/ontrack/errorhandling/ValidationException.kt
+++ b/backend/src/main/kotlin/de/ashman/ontrack/errorhandling/ValidationException.kt
@@ -1,0 +1,9 @@
+package de.ashman.ontrack.errorhandling
+
+class ValidationException(
+    val errors: MutableMap<String, List<String>>,
+) : RuntimeException() {
+    constructor(field: String, message: String?) : this(mutableMapOf()) {
+        errors[field] = listOf(message.orEmpty())
+    }
+}

--- a/backend/src/main/kotlin/de/ashman/ontrack/user/application/controller/AccountController.kt
+++ b/backend/src/main/kotlin/de/ashman/ontrack/user/application/controller/AccountController.kt
@@ -1,10 +1,10 @@
 package de.ashman.ontrack.user.application.controller
 
 import com.google.firebase.auth.FirebaseToken
+import de.ashman.ontrack.errorhandling.ValidationException
 import de.ashman.ontrack.user.infrastructure.UserRepository
 import jakarta.transaction.Transactional
 import jakarta.validation.Valid
-import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
@@ -29,14 +29,12 @@ class AccountController(
         @AuthenticationPrincipal token: FirebaseToken,
         @RequestBody @Valid accountSettings: AccountSettingsDto
     ): ResponseEntity<String> {
-        val validationResult = validateUsername(accountSettings.username)
-        if (validationResult != null) {
-            return ResponseEntity
-                .status(HttpStatus.CONFLICT)
-                .body(validationResult)
+        val user = userRepository.getReferenceById(token.uid)
+        val usernameChanged = !user.username.equals(accountSettings.username)
+        if (usernameChanged && userRepository.existsUserByUsername(accountSettings.username)) {
+            throw ValidationException("username", "Username is taken")
         }
 
-        val user = userRepository.getReferenceById(token.uid)
         user.updateAccountSettings(
             name = accountSettings.name,
             username = accountSettings.username
@@ -52,22 +50,8 @@ class AccountController(
         @RequestBody profilePictureUrl: String,
     ): ResponseEntity<Unit> {
         val user = userRepository.getReferenceById(token.uid)
-
         user.changeProfilePicture(profilePictureUrl)
 
         return ResponseEntity.ok().build()
-    }
-
-    private fun validateUsername(username: String?): String? {
-        if (username.isNullOrBlank()) return "USERNAME_EMPTY"
-        if (username.contains(" ")) return "USERNAME_WHITESPACE"
-        if (username.length < 5) return "USERNAME_TOO_SHORT"
-        if (username.length > 25) return "USERNAME_TOO_LONG"
-        if (username.any { it.isUpperCase() }) return "USERNAME_NO_UPPERCASE"
-
-        val allowedPattern = "^[a-z0-9_.]*$".toRegex()
-        if (!allowedPattern.matches(username)) return "USERNAME_INVALID_CHARACTERS"
-
-        return null
     }
 }

--- a/backend/src/main/kotlin/de/ashman/ontrack/user/application/controller/AccountSettingsDto.kt
+++ b/backend/src/main/kotlin/de/ashman/ontrack/user/application/controller/AccountSettingsDto.kt
@@ -1,6 +1,14 @@
 package de.ashman.ontrack.user.application.controller
 
+import jakarta.validation.constraints.Pattern
+import org.hibernate.validator.constraints.Length
+
 data class AccountSettingsDto(
+    @field:Length(min = 6, max = 25)
+    @field:Pattern(
+        regexp = "[a-z0-9_.]*",
+        message = "Only lowercase letters, numbers and special characters ._ are allowed"
+    )
     val username: String,
     val name: String
 )


### PR DESCRIPTION
## Description
This PR introduces a global way to handle error responses. It follows the Problem details defined in RFC 9457.
The response looks as follows:
```
{
  "type": "ValidationError",       # describes the error type
  "title": "Conflict",
  "status": 409,
  "detail": "Validation failed for one or more fields",  # is a description of the error
  "instance": "/account",   # path at which the error occurred
  "errors": {                        # specific for validation error
    "username": [               # property which is faulty
     "Only lowercase letters, numbers and special characters ._ are allowed",         # list of error messages
      "length must be between 6 and 25"
    ],
    ...
    "name": [ "Cannot be blank" ]
  }
}
```

This improves the current validation handling. 
If multiple values within a request are faulty, you receive feedback for all of them at once.
It also utilizes the springs bean validation. See the `AccountSettingsDto` as an example.

Now we need to adjust the frontend to handle the response. 
I suggest we build a generic component that can handles these things as the structure of validation errors will always be the same.

PS we accidentally removed the unique username check in the last PR - I added it back now.

### Points of discussion
- Should the error message be constructed in the backend or frontend?
- Error response format

## How to test
1. Obtain an access token for an user
    - Set a breakpoint in `FirebaseAuthFilter.kt` and start debug. 
    - Send a request from the app (login, change account settings etc.)
    - The breakpoint should be hit and you can copy the token value.
2. Run the following request with a faulty username input
```
POST https://api.ontrack.local.riceisnice.dev:8000/account
Authorization: Bearer {{accessToken}}
Content-Type: application/json

{
  "name": "This is a test",
  "username": "123R"
}
```
3. Expect the error response.